### PR TITLE
[#1] Remove animationDelay, it looks odd with other animation

### DIFF
--- a/src/DropModal.js
+++ b/src/DropModal.js
@@ -124,7 +124,6 @@ module.exports = modalFactory({
             margin: 0,
             animationDuration: (willHidden ? hideAnimation : showAnimation).animationDuration,
             animationFillMode: 'forwards',
-            animationDelay: '0.25s',
             animationName: showContentAnimation,
             animationTimingFunction: (willHidden ? hideAnimation : showAnimation).animationTimingFunction
         })


### PR DESCRIPTION
Feel free to close this if you don't think this improve the `DropModal`, but I think this looks better without that extra animation delay.