### PR TITLE
Modal Factory - Remove second call to componentDidMount

### DIFF
--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -51,6 +51,8 @@ module.exports = function(animation){
 
             }.bind(this);
             transitionEvents.addEndEventListener(node, endListener);
+            
+            window.addEventListener("keydown", this.listenKeyboard, true);
         },
 
         render: function() {
@@ -134,10 +136,6 @@ module.exports = function(animation){
                      event.keyCode === 27)) {
                 this.hide();
             }
-        },
-
-        componentDidMount: function() {
-            window.addEventListener("keydown", this.listenKeyboard, true);
         },
 
         componentWillUnmount: function() {


### PR DESCRIPTION
There were two instances of the componentDidMount function inside of the the modal factory.
This caused the first instance of the function to be overwritten.
The effect of this is that the onShow callback would never get called.

Moved the keydown listener functionality into the first declaration of the function, and removed
the second declaration.