### PR TITLE
Set backdrop onClick event as optional by using backdropEvent prop

### DIFF
--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -14,7 +14,8 @@ module.exports = function(animation){
             backdrop: React.PropTypes.oneOfType([
                 React.PropTypes.bool,
                 React.PropTypes.string
-            ])
+            ]),
+            backdropEvent: React.PropTypes.bool
         },
 
         getDefaultProps: function() {
@@ -24,7 +25,8 @@ module.exports = function(animation){
                 onHide: function(){},
                 animation: animation,
                 keyboard: true,
-                backdrop: true
+                backdrop: true,
+                backdropEvent: true
             };
         },
 
@@ -65,7 +67,13 @@ module.exports = function(animation){
             var contentStyle = animation.getContentStyle(willHidden);
             var ref = animation.getRef(willHidden);
             var sharp = animation.getSharp && animation.getSharp(willHidden);
-            var backdrop = this.props.backdrop? <div onClick={this.hide} style={backdropStyle}/>: undefined;
+            
+            var backdropModifiers = {
+                style: backdropStyle,
+                onClick: this.props.backdropEvent ? this.hide : null
+            };
+
+            var backdrop = this.props.backdrop? React.createElement("div", backdropModifiers): undefined;
 
             if(willHidden) {
                 var node = this.refs[ref].getDOMNode();


### PR DESCRIPTION
By exposing the `backdropEvent` boolean prop, it becomes optional to have an onClick event on the backdrop of the modal to dismiss it. 

`<Modal backdropEvent={true} />` enables `hide` on the backdrop's onClick event.
`<Modal backdropEvent={false} />` disables `hide` on the backdrop's onClick event.

Note: Defaults to `true` to keep current functionality.

P.S: The repository doesn't have a Contributing guideline, so if you need me to change anything or if the changes need to be completely dismissed, just let me know. Thank you for this great library!.