### PR TITLE
Add props to allow for custom CSS styles 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,78 @@ var Example = React.createClass({
 * closeOnClick - Close the backdrop element when clicked.
 * onShow - Show callback.
 * onHide - Hide callback.
+* modalStyle - Object of CSS styles passed to the modal
+* backdropStyle - Object of CSS styles passed to the backdrop
+* contentStyle - Object of CSS styles passed to the backdrop
+
+# Custom Styles
+Styles can be passed to override default values.
+
+Custom modal width:
+``` javascript
+var Modal = require('boron/ScaleModal');
+var modalStyle = {
+    width: '80%'
+};
+
+var Example = React.createClass({
+    showModal: function(){
+        this.refs.modal.show();
+    },
+    hideModal: function(){
+        this.refs.modal.hide();
+    },
+    render: function() {
+        return (
+            <div>
+                <button onClick={this.showModal}>Open</button>
+                <Modal ref="modal" modalStyle={modalStyle}>
+                    <h2>I am a dialog</h2>
+                    <button onClick={this.hideModal}>Close</button>
+                </Modal>
+            </div>
+        );
+    }
+});
+```
+
+Red backdrop with a blue modal, rotated at 45 degrees:
+``` javascript
+var Modal = require('boron/FlyModal');
+var modalStyle = {
+    transform: 'rotate(45deg) translateX(-50%)',
+};
+
+var backdropStyle = {
+    backgroundColor: 'red'
+};
+
+var contentStyle = {
+    backgroundColor: 'blue',
+    height: '100%'
+};
+
+var Example = React.createClass({
+    showModal: function(){
+        this.refs.modal.show();
+    },
+    hideModal: function(){
+        this.refs.modal.hide();
+    },
+    render: function() {
+        return (
+            <div>
+                <button onClick={this.showModal}>Open</button>
+                <Modal ref="modal" modalStyle={modalStyle} backdropStyle={backdropStyle} contentStyle={contentStyle}>
+                    <h2>I am a dialog</h2>
+                    <button onClick={this.hideModal}>Close</button>
+                </Modal>
+            </div>
+        );
+    }
+});
+```
+
 
 ## Modals
 

--- a/README.md
+++ b/README.md
@@ -64,16 +64,19 @@ var Example = React.createClass({
 * closeOnClick - Close the backdrop element when clicked.
 * onShow - Show callback.
 * onHide - Hide callback.
-* modalStyle - Object of CSS styles passed to the modal
-* backdropStyle - Object of CSS styles passed to the backdrop
-* contentStyle - Object of CSS styles passed to the backdrop
+* modalStyle - CSS styles to apply to the modal
+* backdropStyle - CSS styles to apply to the backdrop
+* contentStyle - CSS styles to apply to the modal's content
 
 # Custom Styles
-Styles can be passed to override default values.
+Objects consisting of CSS properties/values can be passed as props to the Modal component.
+The values for the CSS properties will either add new properties or override the default property value set for that Modal type.
 
-Custom modal width:
+Modal with 80% width:
 ``` javascript
 var Modal = require('boron/ScaleModal');
+
+// Style object
 var modalStyle = {
     width: '80%'
 };
@@ -102,6 +105,8 @@ var Example = React.createClass({
 Red backdrop with a blue modal, rotated at 45 degrees:
 ``` javascript
 var Modal = require('boron/FlyModal');
+
+// Individual styles for the modal, modal content, and backdrop
 var modalStyle = {
     transform: 'rotate(45deg) translateX(-50%)',
 };

--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -13,6 +13,9 @@ module.exports = function(animation){
             animation: React.PropTypes.object,
             backdrop: React.PropTypes.bool,
             closeOnClick: React.PropTypes.bool,
+            modalStyle: React.PropTypes.object,
+            backdropStyle: React.PropTypes.object,
+            contentStyle: React.PropTypes.object,
         },
 
         getDefaultProps: function() {
@@ -23,7 +26,10 @@ module.exports = function(animation){
                 animation: animation,
                 keyboard: true,
                 backdrop: true,
-                closeOnClick: true
+                closeOnClick: true,
+                modalStyle: {},
+                backdropStyle: {},
+                contentStyle: {},
             };
         },
 
@@ -70,13 +76,26 @@ module.exports = function(animation){
             var ref = animation.getRef(willHidden);
             var sharp = animation.getSharp && animation.getSharp(willHidden);
 
-            var backdrop = this.props.backdrop? <div style={backdropStyle} onClick={this.props.closeOnClick? this.handleBackdropClick: null} />: undefined;
-
-            if (this.props.customStyle) {
-                for (var style in this.props.customStyle) {
-                    modalStyle[style] = this.props.customStyle[style];
+            // Apply custom style properties
+            if (this.props.modalStyle) {
+                for (var style in this.props.modalStyle) {
+                    modalStyle[style] = this.props.modalStyle[style];
                 };
             }
+
+            if (this.props.backdropStyle) {
+                for (var style in this.props.backdropStyle) {
+                    backdropStyle[style] = this.props.backdropStyle[style];
+                };
+            }
+
+            if (this.props.contentStyle) {
+                for (var style in this.props.contentStyle) {
+                    contentStyle[style] = this.props.contentStyle[style];
+                };
+            }
+
+            var backdrop = this.props.backdrop? <div style={backdropStyle} onClick={this.props.closeOnClick? this.handleBackdropClick: null} />: undefined;
 
             if(willHidden) {
                 var node = this.refs[ref];

--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var transitionEvents = require('domkit/transitionEvents');
+var appendVendorPrefix = require('domkit/appendVendorPrefix');
 
 module.exports = function(animation){
 
@@ -78,21 +79,24 @@ module.exports = function(animation){
 
             // Apply custom style properties
             if (this.props.modalStyle) {
-                for (var style in this.props.modalStyle) {
-                    modalStyle[style] = this.props.modalStyle[style];
-                };
+                var prefixedModalStyle = appendVendorPrefix(this.props.modalStyle);
+                for (var style in prefixedModalStyle) {
+                    modalStyle[style] = prefixedModalStyle[style];
+                }
             }
 
             if (this.props.backdropStyle) {
-                for (var style in this.props.backdropStyle) {
-                    backdropStyle[style] = this.props.backdropStyle[style];
-                };
+              var prefixedBackdropStyle = appendVendorPrefix(this.props.backdropStyle);
+                for (var style in prefixedBackdropStyle) {
+                    backdropStyle[style] = prefixedBackdropStyle[style];
+                }
             }
 
             if (this.props.contentStyle) {
-                for (var style in this.props.contentStyle) {
-                    contentStyle[style] = this.props.contentStyle[style];
-                };
+              var prefixedContentStyle = appendVendorPrefix(this.props.contentStyle);
+                for (var style in prefixedContentStyle) {
+                    contentStyle[style] = prefixedContentStyle[style];
+                }
             }
 
             var backdrop = this.props.backdrop? <div style={backdropStyle} onClick={this.props.closeOnClick? this.handleBackdropClick: null} />: undefined;


### PR DESCRIPTION
Proposal to add inline styles to Modal elements, which will allow for overwriting default style values.

Attempts to fix #7 and allow manual fixes to #10 and #18 by using `width: '80%'` or any other value for `width` other than the default `500px`. Previously, there was code in `modalFactory.js` that used a prop titled `customStyle` that didn't actually exist. This expands on that idea by exposing 3 new props, 1 for each the styles defined individually for each Modal type (`modalStyle`, `backdropStyle` and `contentStyle`).