### PR TITLE
Allow large content to scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/josuemontano/boron.git"
+    "url": "https://github.com/yuanyan/boron.git"
   },
   "dependencies": {
     "domkit": "^0.0.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yuanyan/boron.git"
+    "url": "https://github.com/josuemontano/boron.git"
   },
   "dependencies": {
     "domkit": "^0.0.1"

--- a/src/DropModal.js
+++ b/src/DropModal.js
@@ -53,9 +53,27 @@ var animation = {
         }
     }),
 
-    showContentAnimation: {},
+    showContentAnimation: insertKeyframesRule({
+        '0%': {
+            opacity: 0,
+            transform: 'translate(0, -20px)'
+        },
+        '100%': {
+            opacity: 1,
+            transform: 'translate(0, 0)'
+        }
+    }),
 
-    hideContentAnimation: {}
+    hideContentAnimation: insertKeyframesRule({
+        '0%': {
+            opacity: 1,
+            transform: 'translate(0, 0)'
+        },
+        '100%': {
+            opacity: 0,
+            transform: 'translate(0, 50px)'
+        }
+    })
 };
 
 var showAnimation = animation.show;

--- a/src/DropModal.js
+++ b/src/DropModal.js
@@ -71,9 +71,21 @@ module.exports = modalFactory({
     getRef: function(willHidden) {
         return 'modal';
     },
+    getWrapperStyle: function() {
+        return appendVendorPrefix({
+            display: "block",
+            position: "fixed",
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: 99999,
+            overflowY: "scroll"
+        });
+    },
     getModalStyle: function(willHidden) {
         return appendVendorPrefix({
-            position: "fixed",
+            position: "absolute",
             width: "500px",
             transform: "translate(-50%, -50%)",
             top: "50%",

--- a/src/DropModal.js
+++ b/src/DropModal.js
@@ -55,16 +55,7 @@ var animation = {
 
     showContentAnimation: {},
 
-    hideContentAnimation: insertKeyframesRule({
-        '0%': {
-            opacity: 1,
-            transform: 'translate(0, 0)'
-        },
-        '100%': {
-            opacity: 0,
-            transform: 'translate(0, 50px)'
-        }
-    })
+    hideContentAnimation: {}
 };
 
 var showAnimation = animation.show;

--- a/src/DropModal.js
+++ b/src/DropModal.js
@@ -53,16 +53,7 @@ var animation = {
         }
     }),
 
-    showContentAnimation: insertKeyframesRule({
-        '0%': {
-            opacity: 0,
-            transform: 'translate(0, -20px)'
-        },
-        '100%': {
-            opacity: 1,
-            transform: 'translate(0, 0)'
-        }
-    }),
+    showContentAnimation: {},
 
     hideContentAnimation: insertKeyframesRule({
         '0%': {

--- a/src/OutlineModal.js
+++ b/src/OutlineModal.js
@@ -108,10 +108,22 @@ module.exports = modalFactory({
             </svg>
         </div>
     },
+    getWrapperStyle: function() {
+        return appendVendorPrefix({
+            display: "block",
+            position: "fixed",
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: 99999,
+            overflowY: "scroll"
+        });
+    },
     getModalStyle: function(willHidden) {
         return appendVendorPrefix({
             zIndex: 1050,
-            position: "fixed",
+            position: "absolute",
             width: "500px",
             transform: "translate3d(-50%, -50%, 0)",
             top: "50%",

--- a/src/WaveModal.js
+++ b/src/WaveModal.js
@@ -204,10 +204,22 @@ module.exports = modalFactory({
     getRef: function(willHidden) {
         return 'content';
     },
+    getWrapperStyle: function() {
+        return appendVendorPrefix({
+            display: "block",
+            position: "fixed",
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: 99999,
+            overflowY: "scroll"
+        });
+    },
     getModalStyle: function(willHidden) {
         return appendVendorPrefix({
             zIndex: 1050,
-            position: "fixed",
+            position: "absolute",
             width: "500px",
             transform: "translate3d(-50%, -50%, 0)",
             top: "50%",

--- a/src/modalFactory.js
+++ b/src/modalFactory.js
@@ -17,6 +17,7 @@ module.exports = function(animation){
             modalStyle: React.PropTypes.object,
             backdropStyle: React.PropTypes.object,
             contentStyle: React.PropTypes.object,
+            wrapperStyle: React.PropTypes.object,
         },
 
         getDefaultProps: function() {
@@ -31,6 +32,7 @@ module.exports = function(animation){
                 modalStyle: {},
                 backdropStyle: {},
                 contentStyle: {},
+                wrapperStyle: {},
             };
         },
 
@@ -74,6 +76,7 @@ module.exports = function(animation){
             var modalStyle = animation.getModalStyle(willHidden);
             var backdropStyle = animation.getBackdropStyle(willHidden);
             var contentStyle = animation.getContentStyle(willHidden);
+            var wrapperStyle = animation.getWrapperStyle();
             var ref = animation.getRef(willHidden);
             var sharp = animation.getSharp && animation.getSharp(willHidden);
 
@@ -99,6 +102,13 @@ module.exports = function(animation){
                 }
             }
 
+            if (this.props.wrapperStyle) {
+              var prefixedWrapperStyle = appendVendorPrefix(this.props.wrapperStyle);
+                for (var style in prefixedWrapperStyle) {
+                    wrapperStyle[style] = prefixedWrapperStyle[style];
+                }
+            }
+
             var backdrop = this.props.backdrop? <div style={backdropStyle} onClick={this.props.closeOnClick? this.handleBackdropClick: null} />: undefined;
 
             if(willHidden) {
@@ -106,7 +116,7 @@ module.exports = function(animation){
                 this.addTransitionListener(node, this.leave);
             }
 
-            return (<span>
+            return (<span style={wrapperStyle}>
                 <div ref="modal" style={modalStyle} className={this.props.className}>
                     {sharp}
                     <div ref="content" tabIndex="-1" style={contentStyle}>


### PR DESCRIPTION
Currently large content inside boron modals is truncated and can't be scrolled. This PR fixes that by positioning the modal container absolutely.